### PR TITLE
Changing "Cannot resolve latest version" to a more compatible color

### DIFF
--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -202,7 +202,7 @@ namespace DotNetOutdated
                 else
                 {
                     console.Write($"{referencedVersion} ", ConsoleColor.Yellow); 
-                    console.Write("Cannot resolve latest version", ConsoleColor.White, ConsoleColor.DarkYellow);
+                    console.Write("Cannot resolve latest version", ConsoleColor.White, ConsoleColor.DarkCyan);
                 }
 
                 if (latestVersion > referencedVersion)


### PR DESCRIPTION
Changing "Cannot resolve latest version" to a more compatible color. The existing color (DarkYellow) looks good with cmd.exe and dark themes but isn't visible at all on DEFAULT PowerShell. DarkRed feels like an error, so a good compromise is DarkCyan which provides enough contrast that it works anywhere. (Note that colors in Window's color are really "indexes" into a color pallette. DarkYellow is light gray in PowerShell.) 

This PR closes #32 

![image](https://user-images.githubusercontent.com/2892/42346542-dee84e5a-8057-11e8-815e-7da3dd779c50.png)
