### PR TITLE
Version cache

### DIFF
--- a/src/DotNetOutdated/Services/INuGetPackageInfoService.cs
+++ b/src/DotNetOutdated/Services/INuGetPackageInfoService.cs
@@ -8,6 +8,6 @@ namespace DotNetOutdated.Services
 {
     internal interface INuGetPackageInfoService
     {
-        Task<IEnumerable<NuGetVersion>> GetAllVersions(string package, List<Uri> sources, bool includePrerelease, NuGetFramework targetFramework, string projectFilePath);
+        Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, List<Uri> sources, bool includePrerelease, NuGetFramework targetFramework, string projectFilePath);
     }
 }

--- a/src/DotNetOutdated/Services/NuGetPackageInfoService.cs
+++ b/src/DotNetOutdated/Services/NuGetPackageInfoService.cs
@@ -38,7 +38,7 @@ namespace DotNetOutdated.Services
 
             return _enabledSources;
         }
-        
+
         private async Task<PackageMetadataResource> FindMetadataResourceForSource(Uri source, string projectFilePath)
         {
             try
@@ -53,8 +53,8 @@ namespace DotNetOutdated.Services
                     // enables secure feeds to work properly
                     var enabledSources = GetEnabledSources(projectFilePath);
                     var enabledSource = enabledSources?.FirstOrDefault(s => s.SourceUri == source);
-                    var sourceRepository = enabledSource != null ? 
-                        new SourceRepository(enabledSource, Repository.Provider.GetCoreV3()) : 
+                    var sourceRepository = enabledSource != null ?
+                        new SourceRepository(enabledSource, Repository.Provider.GetCoreV3()) :
                         Repository.Factory.GetCoreV3(resourceUrl);
 
                     resource = await sourceRepository.GetResourceAsync<PackageMetadataResource>();
@@ -70,7 +70,7 @@ namespace DotNetOutdated.Services
             }
         }
 
-        public async Task<IEnumerable<NuGetVersion>> GetAllVersions(string package, List<Uri> sources, bool includePrerelease, NuGetFramework targetFramework,
+        public async Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, List<Uri> sources, bool includePrerelease, NuGetFramework targetFramework,
             string projectFilePath)
         {
             var allVersions = new List<NuGetVersion>();
@@ -83,7 +83,7 @@ namespace DotNetOutdated.Services
                     {
                         var reducer = new FrameworkReducer();
 
-                        // We need to ensure that we only get package versions which are compatible with the requested target framework. For certain package types (such as 
+                        // We need to ensure that we only get package versions which are compatible with the requested target framework. For certain package types (such as
                         // Roslyn Analyzers) there is no target framework listed for the actual package itself, as it does not contain libraries. So we need to also allow package
                         // versions where there are no dependency sets listed
                         var compatibleMetadataList = (await metadata.GetMetadataAsync(package, includePrerelease, false, _context, NullLogger.Instance, CancellationToken.None))
@@ -96,7 +96,7 @@ namespace DotNetOutdated.Services
                 }
                 catch(HttpRequestException)
                 {
-                    // Suppress HTTP errors when connecting to NuGet sources 
+                    // Suppress HTTP errors when connecting to NuGet sources
                 }
             }
 

--- a/src/DotNetOutdated/Services/NuGetPackageResolutionService.cs
+++ b/src/DotNetOutdated/Services/NuGetPackageResolutionService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
 using NuGet.Versioning;
@@ -9,6 +10,7 @@ namespace DotNetOutdated.Services
     internal class NuGetPackageResolutionService : INuGetPackageResolutionService
     {
         private readonly INuGetPackageInfoService _nugetService;
+        private readonly Dictionary<string, IList<NuGetVersion>> _cache = new Dictionary<string, IList<NuGetVersion>>();
 
         public NuGetPackageResolutionService(INuGetPackageInfoService nugetService)
         {
@@ -24,10 +26,15 @@ namespace DotNetOutdated.Services
                 includePrerelease = true;
             else if (prerelease == PrereleaseReporting.Never)
                 includePrerelease = false;
-            
-            // Get all the available versions
-            var allVersions = await _nugetService.GetAllVersions(packageName, sources, includePrerelease, targetFrameworkName, projectFilePath);
-            
+
+            string cacheKey = (packageName + "-" + includePrerelease + "-" + targetFrameworkName).ToLowerInvariant();
+            if (!_cache.TryGetValue(cacheKey, out var allVersions))
+            {
+                // Get all the available versions
+                allVersions = (await _nugetService.GetAllVersions(packageName, sources, includePrerelease, targetFrameworkName, projectFilePath)).ToList();
+                _cache.Add(cacheKey, allVersions);
+            }
+
             // Determine the floating behaviour
             var floatingBehaviour = includePrerelease ? NuGetVersionFloatBehavior.AbsoluteLatest : NuGetVersionFloatBehavior.Major;
             if (versionLock == VersionLock.Major)

--- a/src/DotNetOutdated/Services/NuGetPackageResolutionService.cs
+++ b/src/DotNetOutdated/Services/NuGetPackageResolutionService.cs
@@ -10,7 +10,7 @@ namespace DotNetOutdated.Services
     internal class NuGetPackageResolutionService : INuGetPackageResolutionService
     {
         private readonly INuGetPackageInfoService _nugetService;
-        private readonly Dictionary<string, IList<NuGetVersion>> _cache = new Dictionary<string, IList<NuGetVersion>>();
+        private readonly Dictionary<string, IReadOnlyList<NuGetVersion>> _cache = new Dictionary<string, IReadOnlyList<NuGetVersion>>();
 
         public NuGetPackageResolutionService(INuGetPackageInfoService nugetService)
         {
@@ -31,7 +31,7 @@ namespace DotNetOutdated.Services
             if (!_cache.TryGetValue(cacheKey, out var allVersions))
             {
                 // Get all the available versions
-                allVersions = (await _nugetService.GetAllVersions(packageName, sources, includePrerelease, targetFrameworkName, projectFilePath)).ToList();
+                allVersions = await _nugetService.GetAllVersions(packageName, sources, includePrerelease, targetFrameworkName, projectFilePath);
                 _cache.Add(cacheKey, allVersions);
             }
 


### PR DESCRIPTION
This PR add simple caching of NuGet package versions.

Before the change `dotnet-outdated -t` took about **12** minutes to scan our solution. With my changes it's now down to **5** minutes. (Without `-t`, from 3:17 down to 1:27).
