### PR TITLE
Exclude unsupported projects when run on solution

### DIFF
--- a/src/DotNetOutdated/Services/DependencyGraphService.cs
+++ b/src/DotNetOutdated/Services/DependencyGraphService.cs
@@ -1,4 +1,8 @@
-﻿using System.IO.Abstractions;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Xml.Linq;
 using DotNetOutdated.Exceptions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -22,6 +26,11 @@ namespace DotNetOutdated.Services
         
         public DependencyGraphSpec GenerateDependencyGraph(string projectPath)
         {
+            if (string.Equals(_fileSystem.Path.GetExtension(projectPath), ".sln", StringComparison.OrdinalIgnoreCase))
+            {
+                return GenerateSolutionDependencyGraph(projectPath);
+            }
+
             string dgOutput = _fileSystem.Path.Combine(_fileSystem.Path.GetTempPath(), _fileSystem.Path.GetTempFileName());
                 
             string[] arguments = {"msbuild", $"\"{projectPath}\"", "/t:GenerateRestoreGraphFile", $"/p:RestoreGraphOutputPath=\"{dgOutput}\""};
@@ -35,9 +44,83 @@ namespace DotNetOutdated.Services
             }
             else
             {
-                throw new CommandValidationException($"Unable to process the the project `{projectPath}. Are you sure this is a valid .NET Core or .NET Standard project type?" +
+                throw new CommandValidationException($"Unable to process the project `{projectPath}. Are you sure this is a valid .NET Core or .NET Standard project type?" +
                                                      $"\r\n\r\nHere is the full error message returned from the Microsoft Build Engine:\r\n\r\n" + runStatus.Output);
             }
+        }
+
+        /// <summary>
+        /// Extracts list of projects from solution file and generates dependency graph only for Microsoft SDK projects.
+        /// Non Microsoft .SDK projects are ignored, because those are not supported by .NET Core MSBuild.
+        /// </summary>
+        private DependencyGraphSpec GenerateSolutionDependencyGraph(string solutionPath)
+        {
+            string directoryPath = _fileSystem.Path.GetDirectoryName(solutionPath);
+            string[] arguments = { "sln", $"\"{solutionPath}\"", "list" };
+            var runStatus = _dotNetRunner.Run(directoryPath, arguments);
+            
+            if (runStatus.IsSuccess)
+            {
+                var dependencyGraphs = new List<DependencyGraphSpec>();
+                using (var reader = new StringReader(runStatus.Output))
+                {
+                    bool readingRows = false;
+                    string line = reader.ReadLine();
+                    while (line != null)
+                    {
+                        if (readingRows)
+                        {
+                            string projectPath = _fileSystem.Path.Combine(directoryPath, line);
+                            if (IsMicrosoftSdkProject(projectPath))
+                            {
+                                dependencyGraphs.Add(GenerateDependencyGraph(projectPath));
+                            }
+                        }
+                        else if (IsHeaderSeparator(line))
+                        {
+                            // Skip first 2 lines:
+                            // Project(s)
+                            // -----------
+                            readingRows = true;
+                        }
+
+                        line = reader.ReadLine();
+                    }
+                }
+
+                return DependencyGraphSpec.Union(dependencyGraphs);
+            }
+            else
+            {
+                throw new CommandValidationException($"Unable to read the solution '{solutionPath}'.\r\n\r\nHere is the full error message returned from the dotnet:\r\n\r\n{runStatus.Output}");
+            }
+        }
+
+        private bool IsMicrosoftSdkProject(string projectPath)
+        {
+            using (var stream = _fileSystem.FileStream.Create(projectPath, FileMode.Open, FileAccess.Read))
+            {
+                var xml = XDocument.Load(stream);
+                return xml.Root.Name.LocalName == "Project" && xml.Root.Attribute("Sdk") != null;
+            }
+        }
+
+        private static bool IsHeaderSeparator(string line)
+        {
+            if (string.IsNullOrEmpty(line))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < line.Length; i++)
+            {
+                if (line[i] != '-')
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/test/DotNetOutdated.Tests/DependencyGraphServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DependencyGraphServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO.Abstractions.TestingHelpers;
 using DotNetOutdated.Exceptions;
 using DotNetOutdated.Services;
@@ -10,6 +11,9 @@ namespace DotNetOutdated.Tests
     public class DependencyGraphServiceTests
     {
         private const string Path = @"c:\path";
+        private const string SolutionPath = @"c:\path\proj.sln";
+        private const string Project1Path = @"c:\path\proj1\proj1.csproj";
+        private const string Project2Path = @"c:\path\proj2\proj2.csproj";
 
         [Fact]
         public void SuccessfulDotNetRunnerExecution_ReturnsDependencyGraph()
@@ -22,7 +26,7 @@ namespace DotNetOutdated.Tests
                 .Returns(new RunStatus(string.Empty, string.Empty, 0))
                 .Callback((string directory, string[] arguments) =>
                 {
-                    // Grab the temp filename that was passed... 
+                    // Grab the temp filename that was passed...
                     string tempFileName = arguments[3].Replace("/p:RestoreGraphOutputPath=", string.Empty).Trim('"');
 
                     // ... and stuff it with our dummy dependency graph
@@ -36,6 +40,9 @@ namespace DotNetOutdated.Tests
 
             // Assert
             Assert.NotNull(dependencyGraph);
+            Assert.Equal(3, dependencyGraph.Projects.Count);
+
+            dotNetRunner.Verify(runner => runner.Run(@"c:\", It.Is<string[]>(a => a[0] == "msbuild" && a[1] == '\"' + Path + '\"')));
         }
         
         [Fact]
@@ -54,5 +61,111 @@ namespace DotNetOutdated.Tests
             Assert.Throws<CommandValidationException>(() => graphService.GenerateDependencyGraph(Path));
         }
 
+        [Fact]
+        public void SolutionPath_ReturnsDependencyGraphForAllProjects()
+        {
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            // Arrange
+            var dotNetRunner = new Mock<IDotNetRunner>();
+
+            string solutionProjects = string.Join(Environment.NewLine, "Project(s)", "-----------", Project1Path, Project2Path);
+            dotNetRunner.Setup(runner => runner.Run(It.IsAny<string>(), It.Is<string[]>(a => a[0] == "sln")))
+                .Returns(new RunStatus(solutionProjects, string.Empty, 0));
+
+            dotNetRunner.Setup(runner => runner.Run(It.IsAny<string>(), It.Is<string[]>(a => a[0] == "msbuild")))
+                .Returns(new RunStatus(string.Empty, string.Empty, 0))
+                .Callback((string directory, string[] arguments) =>
+                {
+                    // Grab the temp filename that was passed...
+                    string tempFileName = arguments[3].Replace("/p:RestoreGraphOutputPath=", string.Empty).Trim('"');
+
+                    // ... and stuff it with our dummy dependency graph
+                    string dependencyGraphFile = arguments[1] == '\"' + Project1Path + '\"' ? "test.dg" : "empty.dg";
+                    mockFileSystem.AddFileFromEmbeddedResource(tempFileName, GetType().Assembly, "DotNetOutdated.Tests.TestData." + dependencyGraphFile);
+                });
+
+            mockFileSystem.AddFileFromEmbeddedResource(Project1Path, GetType().Assembly, "DotNetOutdated.Tests.TestData.MicrosoftSdk.xml");
+            mockFileSystem.AddFileFromEmbeddedResource(Project2Path, GetType().Assembly, "DotNetOutdated.Tests.TestData.MicrosoftSdk.xml");
+
+            var graphService = new DependencyGraphService(dotNetRunner.Object, mockFileSystem);
+
+            // Act
+            var dependencyGraph = graphService.GenerateDependencyGraph(SolutionPath);
+
+            // Assert
+            Assert.NotNull(dependencyGraph);
+            Assert.Equal(4, dependencyGraph.Projects.Count);
+
+            dotNetRunner.Verify(runner => runner.Run(Path, It.Is<string[]>(a => a[0] == "sln" && a[2] == "list" && a[1] == '\"' + SolutionPath + '\"')));
+            dotNetRunner.Verify(runner => runner.Run(@"c:\path\proj1", It.Is<string[]>(a => a[0] == "msbuild" && a[1] == '\"' + Project1Path + '\"')));
+            dotNetRunner.Verify(runner => runner.Run(@"c:\path\proj2", It.Is<string[]>(a => a[0] == "msbuild" && a[1] == '\"' + Project2Path + '\"')));
+        }
+
+        [Fact]
+        public void SolutionPathWithLegacyProject_ReturnsDependencyGraphForSingleProjects()
+        {
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            // Arrange
+            var dotNetRunner = new Mock<IDotNetRunner>();
+
+            string solutionProjects = string.Join(Environment.NewLine, "Project(s)", "-----------", Project1Path, Project2Path);
+            dotNetRunner.Setup(runner => runner.Run(It.IsAny<string>(), It.Is<string[]>(a => a[0] == "sln")))
+                .Returns(new RunStatus(solutionProjects, string.Empty, 0));
+
+            dotNetRunner.Setup(runner => runner.Run(It.IsAny<string>(), It.Is<string[]>(a => a[0] == "msbuild")))
+                .Returns(new RunStatus(string.Empty, string.Empty, 0))
+                .Callback((string directory, string[] arguments) =>
+                {
+                    // Grab the temp filename that was passed...
+                    string tempFileName = arguments[3].Replace("/p:RestoreGraphOutputPath=", string.Empty).Trim('"');
+
+                    // ... and stuff it with our dummy dependency graph
+                    string dependencyGraphFile = arguments[1] == '\"' + Project1Path + '\"' ? "test.dg" : "empty.dg";
+                    mockFileSystem.AddFileFromEmbeddedResource(tempFileName, GetType().Assembly, "DotNetOutdated.Tests.TestData." + dependencyGraphFile);
+                });
+
+            mockFileSystem.AddFileFromEmbeddedResource(Project1Path, GetType().Assembly, "DotNetOutdated.Tests.TestData.LegacySdk.xml");
+            mockFileSystem.AddFileFromEmbeddedResource(Project2Path, GetType().Assembly, "DotNetOutdated.Tests.TestData.MicrosoftSdk.xml");
+
+            var graphService = new DependencyGraphService(dotNetRunner.Object, mockFileSystem);
+
+            // Act
+            var dependencyGraph = graphService.GenerateDependencyGraph(SolutionPath);
+
+            // Assert
+            Assert.NotNull(dependencyGraph);
+            Assert.Equal(1, dependencyGraph.Projects.Count);
+
+            dotNetRunner.Verify(runner => runner.Run(Path, It.Is<string[]>(a => a[0] == "sln" && a[2] == "list" && a[1] == '\"' + SolutionPath + '\"')));
+            dotNetRunner.Verify(runner => runner.Run(@"c:\path\proj2", It.Is<string[]>(a => a[0] == "msbuild" && a[1] == '\"' + Project2Path + '\"')));
+            dotNetRunner.Verify(runner => runner.Run(It.IsAny<string>(), It.Is<string[]>(a => a[0] == "msbuild" && a[1] != '\"' + Project2Path + '\"')), Times.Never());
+        }
+
+        [Fact]
+        public void EmptySolution_ReturnsEmptyDependencyGraph()
+        {
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            // Arrange
+            var dotNetRunner = new Mock<IDotNetRunner>();
+
+            string solutionProjects = string.Join(Environment.NewLine, "Project(s)", "-----------");
+            dotNetRunner.Setup(runner => runner.Run(It.IsAny<string>(), It.Is<string[]>(a => a[0] == "sln")))
+                .Returns(new RunStatus(solutionProjects, string.Empty, 0));
+
+            var graphService = new DependencyGraphService(dotNetRunner.Object, mockFileSystem);
+
+            // Act
+            var dependencyGraph = graphService.GenerateDependencyGraph(SolutionPath);
+
+            // Assert
+            Assert.NotNull(dependencyGraph);
+            Assert.Equal(0, dependencyGraph.Projects.Count);
+
+            dotNetRunner.Verify(runner => runner.Run(Path, It.Is<string[]>(a => a[0] == "sln" && a[2] == "list" && a[1] == '\"' + SolutionPath + '\"')));
+            dotNetRunner.Verify(runner => runner.Run(It.IsAny<string>(), It.Is<string[]>(a => a[0] == "msbuild")), Times.Never());
+        }
     }
 }

--- a/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
+++ b/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
@@ -19,7 +19,9 @@
     <ProjectReference Include="..\..\src\DotNetOutdated\DotNetOutdated.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="TestData\test.dg" />
-    <EmbeddedResource Include="TestData\test.dg" />
+    <None Remove="TestData\*.dg" />
+    <None Remove="TestData\*.xml" />
+    <EmbeddedResource Include="TestData\*.dg" />
+    <EmbeddedResource Include="TestData\*.xml" />
   </ItemGroup>
 </Project>

--- a/test/DotNetOutdated.Tests/TestData/LegacySdk.xml
+++ b/test/DotNetOutdated.Tests/TestData/LegacySdk.xml
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FACEB12B-CBBD-4451-9FE9-95563FE2C55C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ConsoleApp2</RootNamespace>
+    <AssemblyName>ConsoleApp2</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/test/DotNetOutdated.Tests/TestData/MicrosoftSdk.xml
+++ b/test/DotNetOutdated.Tests/TestData/MicrosoftSdk.xml
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test/DotNetOutdated.Tests/TestData/empty.dg
+++ b/test/DotNetOutdated.Tests/TestData/empty.dg
@@ -1,0 +1,59 @@
+{
+  "format": 1,
+  "restore": {
+    "C:\\Users\\rasto\\source\\repos\\ConsoleApp1\\ConsoleApp1\\ConsoleApp1.csproj": {}
+  },
+  "projects": {
+    "C:\\Users\\rasto\\source\\repos\\ConsoleApp1\\ConsoleApp1\\ConsoleApp1.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\rasto\\source\\repos\\ConsoleApp1\\ConsoleApp1\\ConsoleApp1.csproj",
+        "projectName": "ConsoleApp1",
+        "projectPath": "C:\\Users\\rasto\\source\\repos\\ConsoleApp1\\ConsoleApp1\\ConsoleApp1.csproj",
+        "packagesPath": "C:\\Users\\rasto\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\rasto\\source\\repos\\ConsoleApp1\\ConsoleApp1\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\rasto\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "netcoreapp2.1"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "netcoreapp2.1": {
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        }
+      },
+      "frameworks": {
+        "netcoreapp2.1": {
+          "dependencies": {
+            "Microsoft.NETCore.App": {
+              "target": "Package",
+              "version": "[2.1.0, )",
+              "autoReferenced": true
+            }
+          },
+          "imports": [
+            "net461"
+          ],
+          "assetTargetFallback": true,
+          "warn": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #58

When the tool detects solution file, it extracts list of projects from solution and then analyzes dependencies on each project separately. Analysis is run only on projects, which use Microsoft .NET SDK.