### PR TITLE
Add option to return non-zero exit code when updates are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A .NET Core global tool to display outdated NuGet packages in a project
 - [Handling pre-release versions](#handling-pre-release-versions)
 - [Locking to the current major or minor release](#locking-to-the-current-major-or-minor-release)
 - [Reporting on transitive dependencies](#reporting-on-transitive-dependencies)
+- [Failing when updates are available](#failing-when-updates-are-available)
 - [Auto-references](#auto-references)
 - [FAQ](#faq)
 
@@ -54,6 +55,7 @@ Options:
   -vl|--version-lock <VERSION_LOCK>          Specifies whether the package should be locked to the current Major or Minor version. Possible values: None (default), Major or Minor.
   -t|--transitive                            Specifies whether it should detect transitive dependencies.
   -td|--transitive-depth <TRANSITIVE_DEPTH>  Defines how many levels deep transitive dependencies should be analyzed. Integer value (default = 1)
+  -f|--fail-on-updates                       Specifies whether it should return a non-zero exit code when updates are found.
   -u|--upgrade:<TYPE>                        Specifies whether outdated packages should be upgraded. Possible values for <TYPE> is Auto (default) or Prompt.
 ```
 
@@ -110,6 +112,10 @@ Passing a value of `Minor` will only report on later packages in the current min
 You can also specify how many levels deep it should analyze transitive dependencies with the `-td|--transitive-depth` option. You can pass an integer value for this option (the default value is `1`).
 
 **Be careful with these options!**. If you try and analyze dependencies too many levels deep, the analysis can take a very long time.
+
+## Failing when updates are available
+
+**dotnet-outdated** can be easily incorporated into your build process. You can optionally enable a non-zero return code when updates are found to make failing a build easy to configure. To enable this option you can pass the `-f|--fail-on-updates` option.
 
 ## Auto-references
 

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -68,6 +68,10 @@ namespace DotNetOutdated
             ShortName = "u", LongName = "upgrade", ValueName = "TYPE")]
         public (bool HasValue, UpgradeType UpgradeType) Upgrade { get; set; }
         
+        [Option(CommandOptionType.NoValue, Description = "Specifies whether it should return a non-zero exit code when updates are found.",
+            ShortName = "f", LongName = "fail-on-updates")]
+        public bool FailOnUpdates { get; set; } = false;
+
         public static int Main(string[] args)
         {
             using (var services = new ServiceCollection()
@@ -154,7 +158,12 @@ namespace DotNetOutdated
                     console.WriteLine();
                     console.WriteLine("You can upgrade packages to the latest version by passing the -u or -u:prompt option.");
                 }
-                
+
+                if (FailOnUpdates && UpdatesExist(projects))
+                {
+                    return 2;
+                }
+
                 return 0;
             }
             catch (CommandValidationException e)
@@ -271,6 +280,15 @@ namespace DotNetOutdated
 
             console.Write($"{matching}");
             console.Write(rest, GetUpgradeSeverityColor(latestVersion, resolvedVersion));
+        }
+
+        internal static bool UpdatesExist(List<Project> projects)
+        {
+            var dependenciesWithUpdates = projects
+                .SelectMany(p => p.TargetFrameworks)
+                .SelectMany(f => f.Dependencies)
+                .Where(d => d.LatestVersion > d.ResolvedVersion);
+            return dependenciesWithUpdates.Any();
         }
 
         private void ReportOutdatedDependencies(List<Project> projects, IConsole console)

--- a/test/DotNetOutdated.Tests/UpdatesExistTests.cs
+++ b/test/DotNetOutdated.Tests/UpdatesExistTests.cs
@@ -1,0 +1,95 @@
+using NuGet.Versioning;
+using System.Collections.Generic;
+using Xunit;
+using DotNetOutdated.Services;
+
+namespace DotNetOutdated.Tests
+{
+    public class UpdatesExistTests
+    {
+        [Fact]
+        public void ProjectsWithUpdates_ReturnsTrue()
+        {
+            // Arrange
+            var dependencyWithUpdate = new Project.Dependency
+            {
+                ResolvedVersion = new NuGetVersion("1.0.0"),
+                LatestVersion = new NuGetVersion("1.0.1")
+            };
+            var dependencyWithoutUpdate = new Project.Dependency
+            {
+                ResolvedVersion = new NuGetVersion("1.0.0"),
+                LatestVersion = new NuGetVersion("1.0.0")
+            };
+            var targetFrameworkWithUpdate = new Project.TargetFramework
+            {
+                Dependencies = new List<Project.Dependency>
+                {
+                    dependencyWithoutUpdate,
+                    dependencyWithUpdate
+                }
+            };
+            var targetFrameworkWithoutUpdate = new Project.TargetFramework
+            {
+                Dependencies = new List<Project.Dependency>
+                {
+                    dependencyWithoutUpdate,
+                    dependencyWithoutUpdate
+                }
+            };
+            var projects = new List<Project>
+            {
+                new Project
+                {
+                    TargetFrameworks = new List<Project.TargetFramework>
+                    {
+                        targetFrameworkWithoutUpdate,
+                        targetFrameworkWithUpdate
+                    }
+                }
+            };
+
+            // Act
+            var updatesExist = Program.UpdatesExist(projects);
+
+            // Assert
+            Assert.True(updatesExist);
+        }
+
+        [Fact]
+        public void ProjectsWithoutUpdates_ReturnsFalse()
+        {
+            // Arrange
+            var dependencyWithoutUpdate = new Project.Dependency
+            {
+                ResolvedVersion = new NuGetVersion("1.0.0"),
+                LatestVersion = new NuGetVersion("1.0.0")
+            };
+            var targetFrameworkWithoutUpdate = new Project.TargetFramework
+            {
+                Dependencies = new List<Project.Dependency>
+                {
+                    dependencyWithoutUpdate,
+                    dependencyWithoutUpdate
+                }
+            };
+            var projects = new List<Project>
+            {
+                new Project
+                {
+                    TargetFrameworks = new List<Project.TargetFramework>
+                    {
+                        targetFrameworkWithoutUpdate,
+                        targetFrameworkWithoutUpdate
+                    }
+                }
+            };
+
+            // Act
+            var updatesExist = Program.UpdatesExist(projects);
+
+            // Assert
+            Assert.False(updatesExist);
+        }
+    }
+}


### PR DESCRIPTION
Addresses issue #93 

- add -f|--fail-on-updates parameter
- add Program.UpdatesExist() static method
- return exit code 2 if enabled and updates exist