### PR TITLE
Add option to generate a text report

### DIFF
--- a/src/DotNetOutdated/OutputFormat.cs
+++ b/src/DotNetOutdated/OutputFormat.cs
@@ -2,6 +2,7 @@
 {
     public enum OutputFormat
     {
-        Json
+        Json,
+        Text
     }
 }

--- a/src/DotNetOutdated/OutputFormat.cs
+++ b/src/DotNetOutdated/OutputFormat.cs
@@ -1,0 +1,7 @@
+﻿namespace DotNetOutdated
+{
+    public enum OutputFormat
+    {
+        Json
+    }
+}

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -74,9 +74,14 @@ namespace DotNetOutdated
             ShortName = "f", LongName = "fail-on-updates")]
         public bool FailOnUpdates { get; set; } = false;
 
-        [Option(CommandOptionType.SingleValue, Description = "Specifies the filename for a generated JSON report.",
+        [Option(CommandOptionType.SingleValue, Description = "Specifies the filename for a generated report (Json by default).",
             ShortName = "o", LongName = "output")]
         public string OutputFilename { get; set; } = null;
+
+        [Option(CommandOptionType.SingleValue, Description = "Specifies the output format for the generated report. " +
+                                                             "Possible values: Json (default).",
+            ShortName = "of", LongName = "output-format")]
+        public OutputFormat OutputFileFormat { get; set; } = OutputFormat.Json;
 
         public static int Main(string[] args)
         {
@@ -416,12 +421,8 @@ namespace DotNetOutdated
             if (OutputFilename != null)
             {
                 Console.WriteLine();
-                Console.WriteLine("Generating JSON report...");
-                var report = new Report
-                {
-                    Projects = projects
-                };
-                _fileSystem.File.WriteAllText(OutputFilename, JsonConvert.SerializeObject(report, Formatting.Indented));
+                Console.WriteLine(string.Format("Generating {0} report...", OutputFileFormat));
+                _fileSystem.File.WriteAllText(OutputFilename, Report.GetJsonReportContent(projects));
                 Console.WriteLine();
             }
         }

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -79,7 +79,7 @@ namespace DotNetOutdated
         public string OutputFilename { get; set; } = null;
 
         [Option(CommandOptionType.SingleValue, Description = "Specifies the output format for the generated report. " +
-                                                             "Possible values: Json (default).",
+                                                             "Possible values: Json (default) or Text.",
             ShortName = "of", LongName = "output-format")]
         public OutputFormat OutputFileFormat { get; set; } = OutputFormat.Json;
 
@@ -422,7 +422,17 @@ namespace DotNetOutdated
             {
                 Console.WriteLine();
                 Console.WriteLine(string.Format("Generating {0} report...", OutputFileFormat));
-                _fileSystem.File.WriteAllText(OutputFilename, Report.GetJsonReportContent(projects));
+                string reportContent;
+                switch (OutputFileFormat)
+                {
+                    case OutputFormat.Text:
+                        reportContent = Report.GetTextReportContent(projects);
+                        break;
+                    default:
+                        reportContent = Report.GetJsonReportContent(projects);
+                        break;
+                }
+                _fileSystem.File.WriteAllText(OutputFilename, reportContent);
                 Console.WriteLine();
             }
         }

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Globalization;
-using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Net.NetworkInformation;

--- a/src/DotNetOutdated/Services/ReportHelpers.cs
+++ b/src/DotNetOutdated/Services/ReportHelpers.cs
@@ -33,5 +33,14 @@ namespace DotNetOutdated.Services
     public class Report
     {
         public List<Project> Projects { get; set; }
+
+        public static string GetJsonReportContent(List<Project> projects)
+        {
+            var report = new Report
+            {
+                Projects = projects
+            };
+            return JsonConvert.SerializeObject(report, Formatting.Indented);
+        }
     }
 }

--- a/src/DotNetOutdated/Services/ReportHelpers.cs
+++ b/src/DotNetOutdated/Services/ReportHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -33,6 +34,38 @@ namespace DotNetOutdated.Services
     public class Report
     {
         public List<Project> Projects { get; set; }
+
+        internal static string GetTextReportLine(Project project, Project.TargetFramework targetFramework, Project.Dependency dependency)
+        {
+            var upgradeSeverity = "";
+            if (dependency.UpgradeSeverity.HasValue)
+            {
+                upgradeSeverity = Enum.GetName(typeof(DependencyUpgradeSeverity), dependency.UpgradeSeverity);
+            }
+            return string.Format("{0};{1};{2};{3};{4};{5}",
+                project.Name,
+                targetFramework.Name,
+                dependency.Name,
+                dependency.ResolvedVersion,
+                dependency.LatestVersion,
+                upgradeSeverity);
+        }
+
+        public static string GetTextReportContent(List<Project> projects)
+        {
+            var sb = new StringBuilder();
+            foreach (var project in projects)
+            {
+                foreach (var targetFramework in project.TargetFrameworks)
+                {
+                    foreach (var dependency in targetFramework.Dependencies)
+                    {
+                        sb.AppendLine(Report.GetTextReportLine(project, targetFramework, dependency));
+                    }
+                }
+            }
+            return sb.ToString();
+        }
 
         public static string GetJsonReportContent(List<Project> projects)
         {

--- a/test/DotNetOutdated.Tests/TextReportTests.cs
+++ b/test/DotNetOutdated.Tests/TextReportTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using McMaster.Extensions.CommandLineUtils;
+using Moq;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+using Xunit;
+using Xunit.Abstractions;
+using DotNetOutdated.Services;
+
+namespace DotNetOutdated.Tests
+{
+    public class TextReportTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public TextReportTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [InlineData("DotNetOutdated", 
+            ".NETCoreApp",
+            "2.1", 
+            "NuGet.Versioning",
+            "4.8.0-preview1.5156",
+            "4.8.0-preview1.5156",
+            "DotNetOutdated;.NETCoreApp,Version=v2.1;NuGet.Versioning;4.8.0-preview1.5156;4.8.0-preview1.5156;Major")]
+        [InlineData("Some.Awesome.Project", 
+            ".NETStandard",
+            "2.0", 
+            "Some.Awesome.Package",
+            "1.2.0",
+            "1.2.0",
+            "Some.Awesome.Project;.NETStandard,Version=v2.0;Some.Awesome.Package;1.2.0;1.2.0;None")]
+        [InlineData("Some.Awesome.Project", 
+            ".NETStandard",
+            "2.0", 
+            "Some.Awesome.Package",
+            "1.2.0",
+            "1.2.1",
+            "Some.Awesome.Project;.NETStandard,Version=v2.0;Some.Awesome.Package;1.2.0;1.2.1;Patch")]
+        [InlineData("Some.Awesome.Project", 
+            ".NETStandard",
+            "2.0", 
+            "Some.Awesome.Package",
+            "1.2.0",
+            "1.3.1",
+            "Some.Awesome.Project;.NETStandard,Version=v2.0;Some.Awesome.Package;1.2.0;1.3.1;Minor")]
+        [InlineData("Some.Awesome.Project", 
+            ".NETStandard",
+            "2.0", 
+            "Some.Awesome.Package",
+            "1.2.0",
+            "2.0.0",
+            "Some.Awesome.Project;.NETStandard,Version=v2.0;Some.Awesome.Package;1.2.0;2.0.0;Major")]
+        public void TextReportLine(string projectName, string targetFrameworkName, string targetFrameworkVersion, string dependencyName, string resolved, string latest, string expectedResult)
+        {
+            var project = new Project
+            {
+                Name = projectName
+            };
+            var frameworkVersion = new Version(targetFrameworkVersion);
+            var targetFramework = new Project.TargetFramework
+            {
+                Name = new NuGetFramework(targetFrameworkName, frameworkVersion)
+            };
+            var dependency = new Project.Dependency
+            {
+                Name = dependencyName,
+                ResolvedVersion = new NuGetVersion(resolved),
+            };
+            if (latest != null)
+            {
+                dependency.LatestVersion = new NuGetVersion(latest);
+            }
+
+            var actualResult = Report.GetTextReportLine(project, targetFramework, dependency);
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Theory]
+        [InlineData("Some.Awesome.Project", 
+            ".NETStandard",
+            "2.0", 
+            "Some.Awesome.Package",
+            "1.2.0",
+            "Some.Awesome.Project;.NETStandard,Version=v2.0;Some.Awesome.Package;1.2.0;;")]
+        public void TextReportLineWithoutLatestVersion(string projectName, string targetFrameworkName, string targetFrameworkVersion, string dependencyName, string resolved, string expectedResult)
+        {
+            var project = new Project
+            {
+                Name = projectName
+            };
+            var frameworkVersion = new Version(targetFrameworkVersion);
+            var targetFramework = new Project.TargetFramework
+            {
+                Name = new NuGetFramework(targetFrameworkName, frameworkVersion)
+            };
+            var dependency = new Project.Dependency
+            {
+                Name = dependencyName,
+                ResolvedVersion = new NuGetVersion(resolved),
+            };
+
+            var actualResult = Report.GetTextReportLine(project, targetFramework, dependency);
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+    }
+}


### PR DESCRIPTION
Addresses issue #29 

Please note these changes are based on PR #100 so might need some re-work pending review of those changes.

In keeping with #100 the option is -ot or --output-text

Example output...

```
Patros.AuthenticatedHttpClient.Basic;.NETStandard,Version=v2.0;NETStandard.Library;2.0.3;;
Patros.AuthenticatedHttpClient.Basic;.NETStandard,Version=v2.0;Newtonsoft.Json;11.0.2;11.0.2;None
Patros.AuthenticatedHttpClient.AzureAd;.NETStandard,Version=v2.0;Microsoft.IdentityModel.Clients.ActiveDirectory;3.19.8;4.3.0;Major
Patros.AuthenticatedHttpClient.AzureAd;.NETStandard,Version=v2.0;NETStandard.Library;2.0.3;;
Patros.AuthenticatedHttpClient.AzureAppServiceManagedIdentity;.NETStandard,Version=v2.0;Microsoft.Azure.Services.AppAuthentication;1.0.3;1.0.3;None
Patros.AuthenticatedHttpClient.AzureAppServiceManagedIdentity;.NETStandard,Version=v2.0;NETStandard.Library;2.0.3;;
Patros.AuthenticatedHttpClient.Basic.Tests;.NETCoreApp,Version=v2.1;Microsoft.NET.Test.Sdk;15.8.0;15.9.0;Minor
Patros.AuthenticatedHttpClient.Basic.Tests;.NETCoreApp,Version=v2.1;Microsoft.NETCore.App;2.1.0;;
Patros.AuthenticatedHttpClient.Basic.Tests;.NETCoreApp,Version=v2.1;xunit;2.3.1;2.4.1;Minor
Patros.AuthenticatedHttpClient.Basic.Tests;.NETCoreApp,Version=v2.1;xunit.runner.visualstudio;2.3.1;2.4.1;Minor
Patros.AuthenticatedHttpClient.Basic;.NETStandard,Version=v2.0;NETStandard.Library;2.0.3;;
Patros.AuthenticatedHttpClient.Basic;.NETStandard,Version=v2.0;Newtonsoft.Json;11.0.2;11.0.2;None
```

It's worth noting that if a version cannot be resolved it is an empty value as is the upgrade severity value vs "None" which means there is no upgrade.