### PR TITLE
Fix for private nuget feeds

### DIFF
--- a/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
@@ -108,6 +108,9 @@ namespace DotNetOutdated.Core.Services
                             else if (m is LocalPackageSearchMetadata localPackageSearchMetadata)
                             {
                                 allVersions.Add(localPackageSearchMetadata.Identity.Version);
+                            } else
+                            {
+                                allVersions.Add(m.Identity.Version);
                             }
                         };
                     }


### PR DESCRIPTION
this if statement (its really more like switch statement) is missing a 'default case

The type of m was PackageSearchMetadataBuilder which is not one of the 'cases' 

fix for issue: #188

