### PR TITLE
Initialize the NuGet credential provider service

### DIFF
--- a/src/DotNetOutdated.Core/DotNetOutdated.Core.csproj
+++ b/src/DotNetOutdated.Core/DotNetOutdated.Core.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="NuGet.Configuration" Version="5.1.0" />
+    <PackageReference Include="NuGet.Credentials" Version="5.1.0" />
     <PackageReference Include="NuGet.ProjectModel" Version="5.1.0" />
     <PackageReference Include="NuGet.Protocol" Version="5.1.0" />
     <PackageReference Include="NuGet.Versioning" Version="5.1.0" />

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -15,6 +15,7 @@ using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.DependencyInjection;
 using NuGet.Versioning;
 using DotNetOutdated.Core;
+using NuGet.Credentials;
 
 [assembly: InternalsVisibleTo("DotNetOutdated.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
@@ -142,6 +143,8 @@ namespace DotNetOutdated
 
                 // Get all the projects
                 console.Write("Discovering projects...");
+
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(new NuGet.Common.NullLogger(), true);
                 
                 string projectPath = _projectDiscoveryService.DiscoverProject(Path);
 


### PR DESCRIPTION
This PR aims to provide the basic support needed to utilize NuGet credential providers such as the Azure Artifacts credential provider (https://github.com/microsoft/artifacts-credprovider).

This change is enough to make the tool work with our private azure feed assuming said provider is also present on the machine.