### PR TITLE
Added optional parameter for dotnet-outdated to fail only if the new version of the package is older than X days

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Options:
   -exc|--exclude <FILTER_EXCLUDE>            Specifies to only look at packages where the name does not contain the provided string. Culture and case insensitive. If provided multiple times, a single match is enough to exclude a package.
   -o|--output <OUTPUT_FILENAME>              Specifies the filename for a generated report. (Use the -of|--output-format option to specify the format. JSON by default.)
   -of|--output-format <OUTPUT_FILE_FORMAT>   Specifies the output format for the generated report. Possible values: json (default) or csv.
+  -fot|--fail-if-older-than <NUMBER_OF_DAYS> Specifies the number of days the package should be published before failing.
 ```
 
 ![Screenshot of dotnet-outdated](screenshot.png)
@@ -144,6 +145,16 @@ You can choose to include only specific packages by using the `-inc|--include` o
 Conversely, you can exclude specific packages by using the `-exc|--exclude` option. In this case all packages will be analyzed except packages whose name contain the specified value. For example, if you want to exclude packages containing the value "microsoft", you can use the command `dotnet outdated --exclude microsoft`. This option can be passed in multiple times: each package will be evaluated against all filters. One single match is enough to exclude that package.
 
 Please note that for both include and exclude, the comparison is culture and case insensitive.
+
+## Failing only if the new version of the package is older than the number of days
+
+There are some packages that have new updates almost on daily basis, and it might slow down development and will break all CI builds if dotnet-outdated is integrated into the CI - so the development team needs to urgently react on every single update.
+
+This will let the developers finish their job and update the packages on their own pace.
+
+For failing CI builds, a proposed protocol is to have another CI build will be scheduled weekly to inform developers of new packages, and they will react accordingly.
+
+Also, some companies/users do not feel comfortable jumping directly on the newest versions, as they might contain some bugs, and might want to wait for some time before updating to the newest pacakge.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ Please note that for both include and exclude, the comparison is culture and cas
 
 There are some packages that have new updates almost on daily basis, and it might slow down development and will break all CI builds if dotnet-outdated is integrated into the CI - so the development team needs to urgently react on every single update.
 
-This will let the developers finish their job and update the packages on their own pace.
+This command will let the developers finish their job and update the packages on their own pace.
 
-For failing CI builds, a proposed protocol is to have another CI build will be scheduled weekly to inform developers of new packages, and they will react accordingly.
+For failing CI builds, a proposed protocol is to have another CI build which will be scheduled weekly to inform developers of new packages, and they will react accordingly.
 
 Also, some companies/users do not feel comfortable jumping directly on the newest versions, as they might contain some bugs, and might want to wait for some time before updating to the newest pacakge.
 

--- a/src/DotNetOutdated.Core/Services/INuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/INuGetPackageInfoService.cs
@@ -9,6 +9,6 @@ namespace DotNetOutdated.Core.Services
     public interface INuGetPackageInfoService
     {
         Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework, string projectFilePath,
-            bool isDevelopmentDependency);
+            bool isDevelopmentDependency, int olderThanDays);
     }
 }

--- a/src/DotNetOutdated.Core/Services/INuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/INuGetPackageInfoService.cs
@@ -9,6 +9,9 @@ namespace DotNetOutdated.Core.Services
     public interface INuGetPackageInfoService
     {
         Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework, string projectFilePath,
+            bool isDevelopmentDependency);
+
+        Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework, string projectFilePath,
             bool isDevelopmentDependency, int olderThanDays);
     }
 }

--- a/src/DotNetOutdated.Core/Services/INuGetPackageResolutionService.cs
+++ b/src/DotNetOutdated.Core/Services/INuGetPackageResolutionService.cs
@@ -10,6 +10,10 @@ namespace DotNetOutdated.Core.Services
     {
         Task<NuGetVersion> ResolvePackageVersions(string packageName,
             NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange, VersionLock versionLock, PrereleaseReporting prerelease,
+            NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency);
+
+        Task<NuGetVersion> ResolvePackageVersions(string packageName,
+            NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange, VersionLock versionLock, PrereleaseReporting prerelease,
             NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency, int olderThanDays);
     }
 }

--- a/src/DotNetOutdated.Core/Services/INuGetPackageResolutionService.cs
+++ b/src/DotNetOutdated.Core/Services/INuGetPackageResolutionService.cs
@@ -10,6 +10,6 @@ namespace DotNetOutdated.Core.Services
     {
         Task<NuGetVersion> ResolvePackageVersions(string packageName,
             NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange, VersionLock versionLock, PrereleaseReporting prerelease,
-            NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency);
+            NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency, int olderThanDays);
     }
 }

--- a/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
@@ -71,6 +71,12 @@ namespace DotNetOutdated.Core.Services
         }
 
         public async Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework,
+            string projectFilePath, bool isDevelopmentDependency)
+        {
+            return await GetAllVersions(package, sources, includePrerelease, targetFramework, projectFilePath, isDevelopmentDependency, 0);
+        }
+
+        public async Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework,
             string projectFilePath, bool isDevelopmentDependency, int olderThanDays)
         {
             var allVersions = new List<NuGetVersion>();

--- a/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
@@ -71,7 +71,7 @@ namespace DotNetOutdated.Core.Services
         }
 
         public async Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework,
-            string projectFilePath, bool isDevelopmentDependency)
+            string projectFilePath, bool isDevelopmentDependency, int olderThanDays)
         {
             var allVersions = new List<NuGetVersion>();
             foreach (var source in sources)
@@ -82,6 +82,8 @@ namespace DotNetOutdated.Core.Services
                     if (metadata != null)
                     {
                         var compatibleMetadataList = (await metadata.GetMetadataAsync(package, includePrerelease, false, _context, NullLogger.Instance, CancellationToken.None)).ToList();
+
+                        compatibleMetadataList.RemoveAll(c => c.Published.HasValue && c.Published >= DateTimeOffset.UtcNow.AddDays(-olderThanDays));
 
                         // We need to ensure that we only get package versions which are compatible with the requested target framework.
                         // For development dependencies, we do not perform this check

--- a/src/DotNetOutdated.Core/Services/NuGetPackageResolutionService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageResolutionService.cs
@@ -17,7 +17,7 @@ namespace DotNetOutdated.Core.Services
         }
 
         public async Task<NuGetVersion> ResolvePackageVersions(string packageName, NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange,
-            VersionLock versionLock, PrereleaseReporting prerelease, NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency)
+            VersionLock versionLock, PrereleaseReporting prerelease, NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency, int olderThanDays)
         {
             // Determine whether we are interested in pre-releases
             bool includePrerelease = referencedVersion.IsPrerelease;
@@ -30,7 +30,7 @@ namespace DotNetOutdated.Core.Services
             if (!_cache.TryGetValue(cacheKey, out var allVersions))
             {
                 // Get all the available versions
-                allVersions = await _nugetService.GetAllVersions(packageName, sources, includePrerelease, targetFrameworkName, projectFilePath, isDevelopmentDependency);
+                allVersions = await _nugetService.GetAllVersions(packageName, sources, includePrerelease, targetFrameworkName, projectFilePath, isDevelopmentDependency, olderThanDays);
                 _cache.Add(cacheKey, allVersions);
             }
 

--- a/src/DotNetOutdated.Core/Services/NuGetPackageResolutionService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageResolutionService.cs
@@ -17,6 +17,13 @@ namespace DotNetOutdated.Core.Services
         }
 
         public async Task<NuGetVersion> ResolvePackageVersions(string packageName, NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange,
+            VersionLock versionLock, PrereleaseReporting prerelease, NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency)
+        {
+            return await ResolvePackageVersions(packageName, referencedVersion, sources, currentVersionRange, versionLock, prerelease, targetFrameworkName, projectFilePath,
+                isDevelopmentDependency, 0);
+        }
+
+        public async Task<NuGetVersion> ResolvePackageVersions(string packageName, NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange,
             VersionLock versionLock, PrereleaseReporting prerelease, NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency, int olderThanDays)
         {
             // Determine whether we are interested in pre-releases

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -89,6 +89,10 @@ namespace DotNetOutdated
             ShortName = "of", LongName = "output-format")]
         public OutputFormat OutputFileFormat { get; set; } = OutputFormat.Json;
 
+        [Option(CommandOptionType.SingleValue, Description = "Specifies the number of days the package should be published before failing.",
+            ShortName = "fot", LongName = "fail-if-older-than")]
+        public int OlderThanDays { get; set; }
+
         public static int Main(string[] args)
         {
             using (var services = new ServiceCollection()
@@ -390,7 +394,7 @@ namespace DotNetOutdated
                         if (referencedVersion != null)
                         {
                             latestVersion = await _nugetService.ResolvePackageVersions(dependency.Name, referencedVersion, project.Sources, dependency.VersionRange,
-                                VersionLock, Prerelease, targetFramework.Name, project.FilePath, dependency.IsDevelopmentDependency);
+                                VersionLock, Prerelease, targetFramework.Name, project.FilePath, dependency.IsDevelopmentDependency, OlderThanDays);
                         }
 
                         if (referencedVersion == null || latestVersion == null || referencedVersion != latestVersion)

--- a/test/DotNetOutdated.Tests/NuGetPackageResolutionServiceTests.cs
+++ b/test/DotNetOutdated.Tests/NuGetPackageResolutionServiceTests.cs
@@ -31,7 +31,7 @@ namespace DotNetOutdated.Tests
             };
             
             var nuGetPackageInfoService = new Mock<INuGetPackageInfoService>();
-            nuGetPackageInfoService.Setup(service => service.GetAllVersions(packageName, It.IsAny<List<Uri>>(), It.IsAny<bool>(), It.IsAny<NuGetFramework>(), It.IsAny<string>(), It.IsAny<bool>()))
+            nuGetPackageInfoService.Setup(service => service.GetAllVersions(packageName, It.IsAny<List<Uri>>(), It.IsAny<bool>(), It.IsAny<NuGetFramework>(), It.IsAny<string>(), It.IsAny<bool>(), 0))
                 .ReturnsAsync(availableVersions);
             
             _nuGetPackageResolutionService = new NuGetPackageResolutionService(nuGetPackageInfoService.Object);
@@ -49,7 +49,7 @@ namespace DotNetOutdated.Tests
             // Arrange
             
             // Act
-            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(packageName, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, null, null, false);
+            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(packageName, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, null, null, false, 0);
             
             // Assert
             Assert.Equal(NuGetVersion.Parse(latest), latestVersion);


### PR DESCRIPTION
Pull request for #236 

Tests were not added as there are no existing tests for NugetPackageInfoService, where the change was made.