### PR TITLE
Fix #255: Handle missing DOTNET_HOST_PATH environment variable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    "configurations": [
+        {
+            "args": [
+                "${input:projectPath}"
+            ],
+            "console": "internalConsole",
+            "cwd": "${workspaceFolder}/src/DotNetOutdated",
+            "name": ".NET Core Launch (console)",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/.build/bin/DotNetOutdated/Debug/netcoreapp3.0/dotnet-outdated.dll",
+            "request": "launch",
+            "stopAtEntry": false,
+            "type": "coreclr"
+        },
+        {
+            "name": ".NET Core Attach",
+            "processId": "${command:pickProcess}",
+            "request": "attach",
+            "type": "coreclr"
+        }
+    ],
+    "inputs": [
+        {
+            "default": "",
+            "description": "Path against which to run `dotnet outdated`",
+            "id": "projectPath",
+            "type": "promptString"
+        }
+    ],
+    "version": "0.2.0"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+    "tasks": [
+        {
+            "args": [
+                "build",
+                "${workspaceFolder}/DotNetOutdated.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "command": "dotnet",
+            "group": {
+                "isDefault": true,
+                "kind": "build"
+            },
+            "label": "build",
+            "problemMatcher": "$msCompile",
+            "type": "process"
+        }
+    ],
+    "version": "2.0.0"
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 When using an IDE such as Visual Studio, it is easy to find out whether newer versions of the NuGet packages used by your project is available, by using the NuGet Package Manager. However, the .NET Core command-line tools do not provide a built-in way for you to report on outdated NuGet packages.
 
-**dotnet-outdated** is a .NET Core Global tool that allows you to quickly report on any outdated NuGet packages in your .NET Core and .NET Standard projects. 
+**dotnet-outdated** is a .NET Core Global tool that allows you to quickly report on any outdated NuGet packages in your .NET Core and .NET Standard projects.
 
 - [Installation](#installation)
 - [Usage](#usage)
@@ -86,9 +86,15 @@ Lastly, you can specify the path to a solution (`.sln`) or project (`.csproj` or
 
 ## Working with secure feeds
 
-**dotnet-outdated** supports secure NuGet feeds, such as [MyGet](https://www.myget.org). It is suggested that you add these to your sources using the [source command of the NuGet CLI](https://docs.microsoft.com/en-us/nuget/tools/cli-ref-sources). For secure feeds, you can either add a pre-authenticated URL or you can specify the username and password for the feed using the `-UserName` and `-Password` options of the `nuget sources` command.
+**dotnet-outdated** supports secure NuGet feeds, such as [MyGet](https://www.myget.org). It is suggested that you add these to your sources using the [source command of the NuGet CLI](https://docs.microsoft.com/en-us/nuget/tools/cli-ref-sources). For secure feeds, you can do one of the following:
+
+- Add a pre-authenticated URL.
+- Specify the username and password for the feed using the `-UserName` and `-Password` options of the `nuget sources` command.
+- Use a credential provider like [the Azure Artifacts credential provider](https://github.com/microsoft/artifacts-credprovider).
 
 **dotnet-outdated** supports computer-level, user-level and project-level configuration files.
+
+Using credential providers requires an environment variable `DOTNET_HOST_PATH` that is set to the path to the `dotnet` executable (e.g., `/usr/local/share/dotnet/dotnet`). Some versions of the .NET Core SDK do this for you at runtime, some do not. You will get an error message explaining this if the process finds it missing.
 
 ### Issues on macOS
 

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -71,7 +71,7 @@ namespace DotNetOutdated
             ShortName = "f", LongName = "fail-on-updates")]
         public bool FailOnUpdates { get; set; } = false;
 
-        [Option(CommandOptionType.MultipleValue, Description = "Specifies to only look at packages where the name contains the provided string. Culture and case insensitive. If provided multiple times, a single match is enough to include a package.", 
+        [Option(CommandOptionType.MultipleValue, Description = "Specifies to only look at packages where the name contains the provided string. Culture and case insensitive. If provided multiple times, a single match is enough to include a package.",
             ShortName = "inc", LongName = "include")]
         public List<string> FilterInclude { get; set; } = new List<string>();
 
@@ -149,7 +149,7 @@ namespace DotNetOutdated
                 console.Write("Discovering projects...");
 
                 DefaultCredentialServiceUtility.SetupDefaultCredentialService(new NuGet.Common.NullLogger(), true);
-                
+
                 string projectPath = _projectDiscoveryService.DiscoverProject(Path);
 
                 if (!console.IsOutputRedirected)
@@ -159,7 +159,7 @@ namespace DotNetOutdated
 
                 // Analyze the projects
                 console.Write("Analyzing project and restoring packages...");
-                
+
                 var projects = _projectAnalysisService.AnalyzeProject(projectPath, Transitive, TransitiveDepth);
 
                 if (!console.IsOutputRedirected)
@@ -210,13 +210,13 @@ namespace DotNetOutdated
             if (Upgrade.HasValue)
             {
                 console.WriteLine();
-            
+
                 var consolidatedPackages = projects.ConsolidatePackages();
 
                 foreach (var package in consolidatedPackages)
                 {
                     bool upgrade = true;
-                    
+
                     if (Upgrade.UpgradeType == UpgradeType.Prompt)
                     {
                         string resolvedVersion = package.ResolvedVersion?.ToString() ?? "";
@@ -241,7 +241,7 @@ namespace DotNetOutdated
                         console.Write(package.Description, Constants.ReporingColors.PackageName);
                         console.Write("...");
                         console.WriteLine();
-                        
+
                         foreach (var project in package.Projects)
                         {
                             var status = _dotNetAddPackageService.AddPackage(project.ProjectFilePath, package.Name, project.Framework.ToString(), package.LatestVersion);
@@ -265,11 +265,11 @@ namespace DotNetOutdated
                 }
             }
         }
-        
+
         private void PrintColorLegend(IConsole console)
         {
             console.WriteLine("Version color legend:");
-            
+
             console.Write("<red>".PadRight(8), Constants.ReporingColors.MajorVersionUpgrade);
             console.WriteLine(": Major version update or pre-release version. Possible breaking changes.");
             console.Write("<yellow>".PadRight(8), Constants.ReporingColors.MinorVersionUpgrade);
@@ -347,6 +347,15 @@ namespace DotNetOutdated
             if (projects.SelectMany(p => p.TargetFrameworks).SelectMany(f => f.Dependencies).Any(d => d.UpgradeSeverity == DependencyUpgradeSeverity.Unknown))
             {
                 console.WriteLine("Errors occurred while analyzing dependencies for some of your projects. Are you sure you can connect to all your configured NuGet servers?", ConsoleColor.Red);
+                if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_HOST_PATH")))
+                {
+                    // Issue #255: Sometimes the dotnet executable sets this
+                    // variable for you, sometimes it doesn't. If it's not
+                    // present, credential providers will be skipped.
+                    console.WriteLine();
+                    console.WriteLine("Unable to find DOTNET_HOST_PATH environment variable. If you use credential providers for your NuGet sources you need to have this set to the path to the `dotnet` executable.", ConsoleColor.Red);
+                }
+
                 console.WriteLine();
             }
 
@@ -404,7 +413,7 @@ namespace DotNetOutdated
                             ClearCurrentConsoleLine();
                     }
 
-                    if (outdatedDependencies.Count > 0) 
+                    if (outdatedDependencies.Count > 0)
                         outdatedFrameworks.Add(new AnalyzedTargetFramework(targetFramework.Name, outdatedDependencies));
                 }
 
@@ -474,7 +483,7 @@ namespace DotNetOutdated
             console.Write($"[{targetFramework.Name}]", Constants.ReporingColors.TargetFrameworkName);
             console.WriteLine();
         }
-        
+
         public static void ClearCurrentConsoleLine()
         {
             int currentLineCursor = Console.CursorTop;

--- a/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
+++ b/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.1.0" />
     <PackageReference Include="System.IO.Abstractions" Version="7.1.3" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="7.1.3" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
This PR includes:

- Update to README to explain that credential providers are supported but also require `DOTNET_HOST_PATH`.
- Additional info printed out when checking NuGet is not successful - check to see if the required environment variable is missing, tell folks if it is.

There are also a couple of housekeeping things, which I can roll back if needed.

- Support to build and debug using VS Code.
- Removal of some trailing spaces in the documents I edited.
- Update to the test project to allow the DotNetOutdated.Core assembly to control the dependency versions, should make it easier to maintain the test project.