### PR TITLE
"Are you sure you can connect to all your configured NuGet servers?" wrongly occurs if "OlderThan" is used with newly installed package

### DIFF
--- a/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
@@ -74,7 +74,7 @@ namespace DotNetOutdated.Core.Services
 
         public async Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework,
             string projectFilePath, bool isDevelopmentDependency, int olderThanDays)
-        { 
+        {
             var allVersions = new List<NuGetVersion>();
             foreach (var source in sources)
             {

--- a/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
@@ -74,7 +74,7 @@ namespace DotNetOutdated.Core.Services
 
         public async Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework,
             string projectFilePath, bool isDevelopmentDependency, int olderThanDays)
-        {
+        { 
             var allVersions = new List<NuGetVersion>();
             foreach (var source in sources)
             {

--- a/src/DotNetOutdated.Core/Services/NuGetPackageResolutionService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageResolutionService.cs
@@ -35,7 +35,7 @@ namespace DotNetOutdated.Core.Services
             else if (prerelease == PrereleaseReporting.Never)
                 includePrerelease = false;
 
-            string cacheKey = (packageName + "-" + includePrerelease + "-" + targetFrameworkName).ToLowerInvariant();
+            string cacheKey = (packageName + "-" + includePrerelease + "-" + targetFrameworkName + "-" + olderThanDays).ToLowerInvariant();
 
             // Get all the available versions
             var allVersionsRequest = new Lazy<Task<IReadOnlyList<NuGetVersion>>>(() => this._nugetService.GetAllVersions(packageName, sources, includePrerelease, targetFrameworkName, projectFilePath, isDevelopmentDependency, olderThanDays));

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -476,7 +476,23 @@ namespace DotNetOutdated
             }
 
             if (referencedVersion == null || latestVersion == null || referencedVersion != latestVersion)
-                outdatedDependencies.Add(new AnalyzedDependency(dependency, latestVersion));
+            {
+                // special case when there is version installed which is not older than "OlderThan" days makes "latestVersion" to be null
+                if (OlderThanDays > 0 && latestVersion == null)
+                {
+                    NuGetVersion absoluteLatestVersion = await _nugetService.ResolvePackageVersions(dependency.Name, referencedVersion, project.Sources, dependency.VersionRange,
+                        VersionLock, Prerelease, targetFramework.Name, project.FilePath, dependency.IsDevelopmentDependency);
+
+                    if (absoluteLatestVersion == null || referencedVersion > absoluteLatestVersion)
+                    {
+                        outdatedDependencies.Add(new AnalyzedDependency(dependency, latestVersion));
+                    }
+                }
+                else
+                {
+                    outdatedDependencies.Add(new AnalyzedDependency(dependency, latestVersion));
+                }
+            }
         }
 
         private static ConsoleColor GetUpgradeSeverityColor(DependencyUpgradeSeverity? upgradeSeverity)


### PR DESCRIPTION
#327 